### PR TITLE
Add addLiquidityTwoSidesOptimal

### DIFF
--- a/test/IbETHRouter.test.ts
+++ b/test/IbETHRouter.test.ts
@@ -131,7 +131,8 @@ contract('IbETHRouter', ([deployer, alice]) => {
 
   it('should be able to add liquidity with excess ETH and get dust ETH back', async () => {
     await token.approve(ibETHRouter.address, ether('100'), { from: alice });
-    const aliceBalanceBefore = new BN(await web3.eth.getBalance(alice));
+    const aliceETHBalanceBefore = new BN(await web3.eth.getBalance(alice));
+    const aliceTokenBalanceBefore = await token.balanceOf(alice);
     // Adding 100 MOCK requires adding 1 ibETH
     // Deposit 1.045454545454545454 ETH, yield 1 ibETH
     // Only need 1.045454545454545454 ETH, but add 10 ETH
@@ -140,7 +141,11 @@ contract('IbETHRouter', ([deployer, alice]) => {
       value: ether('10'),
     });
     expect(await lp.balanceOf(alice)).to.be.bignumber.above(ether('0'));
-    assertAlmostEqual(new BN(await web3.eth.getBalance(alice)), aliceBalanceBefore.sub(ether('1.045454545454545454')));
+    assertAlmostEqual(
+      new BN(await web3.eth.getBalance(alice)),
+      aliceETHBalanceBefore.sub(ether('1.045454545454545454'))
+    );
+    expect(await token.balanceOf(alice)).to.be.bignumber.equal(aliceTokenBalanceBefore.sub(ether('100')));
     expect(await token.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
     expect(await bank.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
     expect(new BN(await web3.eth.getBalance(ibETHRouter.address))).to.be.bignumber.equal(ether('0'));
@@ -148,7 +153,8 @@ contract('IbETHRouter', ([deployer, alice]) => {
 
   it('should be able to add liquidity with excess MOCK and has some leftover', async () => {
     await token.approve(ibETHRouter.address, ether('100'), { from: alice });
-    const aliceBalanceBefore = await token.balanceOf(alice);
+    const aliceETHBalanceBefore = new BN(await web3.eth.getBalance(alice));
+    const aliceTokenBalanceBefore = await token.balanceOf(alice);
     // Add 100 MOCK requires adding 1 ibETH
     // Deposit 0.1 ETH, yield 0.095652173913043478 ibETH
     // Only need 9.565217391304347800 MOCK, but add 100 MOCK
@@ -157,7 +163,197 @@ contract('IbETHRouter', ([deployer, alice]) => {
       value: ether('0.1'),
     });
     expect(await lp.balanceOf(alice)).to.be.bignumber.above(ether('0'));
-    expect(await token.balanceOf(alice)).to.be.bignumber.equal(aliceBalanceBefore.sub(ether('9.5652173913043478')));
+    assertAlmostEqual(new BN(await web3.eth.getBalance(alice)), aliceETHBalanceBefore.sub(ether('0.1')));
+    expect(await token.balanceOf(alice)).to.be.bignumber.equal(
+      aliceTokenBalanceBefore.sub(ether('9.565217391304347800'))
+    );
+    expect(await token.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
+    expect(await bank.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
+    expect(new BN(await web3.eth.getBalance(ibETHRouter.address))).to.be.bignumber.equal(ether('0'));
+  });
+
+  it('should be able to add liquidity optimally with only ibETH', async () => {
+    const aliceIbETHBalanceBefore = await bank.balanceOf(alice);
+    await bank.approve(ibETHRouter.address, ether('5'), { from: alice });
+    // Sending 5 ibETH, 5*0.5 = 2.5 ibETH should be used to swap optimally for MOCK
+    // Should get slightly less than 250 MOCK from swap.
+    // So should add liquidity total of ~250 MOCK and ~2.5 ibETH and get ~25 lpToken
+    await ibETHRouter.addLiquidityTwoSidesOptimal(ether('5'), 0, 0, alice, FOREVER, {
+      from: alice,
+    });
+    expect(await lp.balanceOf(alice)).to.be.bignumber.equal(ether('24.657979004220051623'));
+    expect(await bank.balanceOf(alice)).to.be.bignumber.closeTo(aliceIbETHBalanceBefore.sub(ether('5')), new BN('1'));
+    expect(await token.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
+    expect(await bank.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
+    expect(new BN(await web3.eth.getBalance(ibETHRouter.address))).to.be.bignumber.equal(ether('0'));
+  });
+
+  it('should be able to add liquidity optimally with only MOCK', async () => {
+    const aliceTokenBalanceBefore = await token.balanceOf(alice);
+    await token.approve(ibETHRouter.address, ether('50'), { from: alice });
+    // Sending 50 MOCK, 50*0.5 = 25 MOCK should be used to swap optimally for ibETH
+    // Should get slightly less than 0.25 ibETH from swap.
+    // So should add liquidity total of ~25 MOCK and ~0.25 ibETH and get ~2.5 lpToken
+    await ibETHRouter.addLiquidityTwoSidesOptimal(0, ether('50'), 0, alice, FOREVER, {
+      from: alice,
+    });
+    expect(await lp.balanceOf(alice)).to.be.bignumber.equal(ether('2.493131844569650832'));
+    expect(await token.balanceOf(alice)).to.be.bignumber.closeTo(aliceTokenBalanceBefore.sub(ether('50')), new BN('1'));
+    expect(await token.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
+    expect(await bank.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
+    expect(new BN(await web3.eth.getBalance(ibETHRouter.address))).to.be.bignumber.equal(ether('0'));
+  });
+
+  it('should be able to add liquidity optimally with more ibETH than required', async () => {
+    const aliceTokenBalanceBefore = await token.balanceOf(alice);
+    const aliceIbETHBalanceBefore = await bank.balanceOf(alice);
+    await bank.approve(ibETHRouter.address, ether('5'), { from: alice });
+    await token.approve(ibETHRouter.address, ether('50'), { from: alice });
+    // Add 50 MOCK requires adding 0.5 ibETH
+    // Sending 5 ibETH, (5-0.5)*0.5 = 2.25 ibETH should be used to swap optimally for MOCK
+    // Should get slightly less than 225 MOCK from swap.
+    // So should add liquidity total of ~275 MOCK and ~2.75 ibETH and get ~27.5 lpToken
+    await ibETHRouter.addLiquidityTwoSidesOptimal(ether('5'), ether('50'), 0, alice, FOREVER, {
+      from: alice,
+    });
+    expect(await lp.balanceOf(alice)).to.be.bignumber.equal(ether('27.220190062987375140'));
+    expect(await token.balanceOf(alice)).to.be.bignumber.closeTo(aliceTokenBalanceBefore.sub(ether('50')), new BN('1'));
+    expect(await bank.balanceOf(alice)).to.be.bignumber.closeTo(aliceIbETHBalanceBefore.sub(ether('5')), new BN('1'));
+    expect(await token.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
+    expect(await bank.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
+    expect(new BN(await web3.eth.getBalance(ibETHRouter.address))).to.be.bignumber.equal(ether('0'));
+  });
+
+  it('should be able to add liquidity optimally with more MOCK than required', async () => {
+    const aliceTokenBalanceBefore = await token.balanceOf(alice);
+    const aliceIbETHBalanceBefore = await bank.balanceOf(alice);
+    await bank.approve(ibETHRouter.address, ether('0.1'), { from: alice });
+    await token.approve(ibETHRouter.address, ether('50'), { from: alice });
+    // Add 0.1 ibETH requires adding 10 MOCK
+    // Sending 50 MOCK, (50-10)*0.5 = 20 MOCK should be used to swap optimally for ibETH
+    // Should get slightly less than 0.2 ibETH from swap.
+    // So should add liquidity total of ~30 MOCK and ~0.3 ibETH and get ~3 lpToken
+    await ibETHRouter.addLiquidityTwoSidesOptimal(ether('0.1'), ether('50'), 0, alice, FOREVER, {
+      from: alice,
+    });
+    expect(await lp.balanceOf(alice)).to.be.bignumber.equal(ether('2.995004473319087933'));
+    expect(await token.balanceOf(alice)).to.be.bignumber.closeTo(aliceTokenBalanceBefore.sub(ether('50')), new BN('1'));
+    expect(await bank.balanceOf(alice)).to.be.bignumber.closeTo(aliceIbETHBalanceBefore.sub(ether('0.1')), new BN('1'));
+    expect(await token.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
+    expect(await bank.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
+    expect(new BN(await web3.eth.getBalance(ibETHRouter.address))).to.be.bignumber.equal(ether('0'));
+  });
+
+  it('should revert when add liquidity optimally with less lpToken than minumum specified', async () => {
+    const aliceTokenBalanceBefore = await token.balanceOf(alice);
+    const aliceIbETHBalanceBefore = await bank.balanceOf(alice);
+    await bank.approve(ibETHRouter.address, ether('0.1'), { from: alice });
+    await token.approve(ibETHRouter.address, ether('50'), { from: alice });
+    // Add 0.1 ibETH requires adding 10 MOCK
+    // Sending 50 MOCK, (50-10)*0.5 = 20 MOCK should be used to swap optimally for ibETH
+    // Should get slightly less than 0.2 ibETH from swap.
+    // So should add liquidity total of ~30 MOCK and ~0.3 ibETH and get ~3 lpToken, but require at least 100 lpToken
+    expectRevert(
+      ibETHRouter.addLiquidityTwoSidesOptimal(ether('0.1'), ether('50'), ether('100'), alice, FOREVER, {
+        from: alice,
+      }),
+      'IbETHRouter: receive less lpToken than amountLPMin'
+    );
+    expect(await lp.balanceOf(alice)).to.be.bignumber.equal(ether('0'));
+    expect(await token.balanceOf(alice)).to.be.bignumber.equal(aliceTokenBalanceBefore);
+    expect(await bank.balanceOf(alice)).to.be.bignumber.equal(aliceIbETHBalanceBefore);
+    expect(await token.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
+    expect(await bank.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
+    expect(new BN(await web3.eth.getBalance(ibETHRouter.address))).to.be.bignumber.equal(ether('0'));
+  });
+
+  it('should be able to add liquidity optimally with only ETH', async () => {
+    const aliceETHBalanceBefore = new BN(await web3.eth.getBalance(alice));
+    // Depositing 5 ETH yield 4.7826087 ibETH
+    // Sending 4.7826087 ibETH, 4.7826087*0.5 = 2.39130435 ibETH should be used to swap optimally for MOCK
+    // Should get slightly less than 239.130435 MOCK from swap.
+    // So should add liquidity total of ~239.13 MOCK and ~2.39 ibETH and get ~23.9 lpToken
+    await ibETHRouter.addLiquidityTwoSidesOptimalETH(0, 0, alice, FOREVER, {
+      from: alice,
+      value: ether('5'),
+    });
+    expect(await lp.balanceOf(alice)).to.be.bignumber.equal(ether('23.598262739768173752'));
+    expect(new BN(await web3.eth.getBalance(alice))).to.be.bignumber.closeTo(
+      aliceETHBalanceBefore.sub(ether('5')),
+      ether('0.01')
+    );
+    expect(await token.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
+    expect(await bank.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
+    expect(new BN(await web3.eth.getBalance(ibETHRouter.address))).to.be.bignumber.equal(ether('0'));
+  });
+
+  it('should be able to add liquidity optimally with more ETH than required', async () => {
+    const aliceTokenBalanceBefore = await token.balanceOf(alice);
+    const aliceETHBalanceBefore = new BN(await web3.eth.getBalance(alice));
+    await token.approve(ibETHRouter.address, ether('50'), { from: alice });
+    // Add 50 MOCK requires adding 0.5 ibETH
+    // Depositing 5 ETH yield 4.7826087 ibETH
+    // Sending 4.7826087 ibETH, (4.7826087-0.5)*0.5 = 2.14130435 ibETH should be used to swap optimally for MOCK
+    // Should get slightly less than 214.130435 MOCK from swap.
+    // So should add liquidity total of ~264 MOCK and ~2.64 ibETH and get ~26.4 lpToken
+    await ibETHRouter.addLiquidityTwoSidesOptimalETH(ether('50'), 0, alice, FOREVER, {
+      from: alice,
+      value: ether('5'),
+    });
+    expect(await lp.balanceOf(alice)).to.be.bignumber.equal(ether('26.157827816948699953'));
+    expect(await token.balanceOf(alice)).to.be.bignumber.closeTo(aliceTokenBalanceBefore.sub(ether('50')), new BN('1'));
+    expect(new BN(await web3.eth.getBalance(alice))).to.be.bignumber.closeTo(
+      aliceETHBalanceBefore.sub(ether('5')),
+      ether('0.01')
+    );
+    expect(await token.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
+    expect(await bank.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
+    expect(new BN(await web3.eth.getBalance(ibETHRouter.address))).to.be.bignumber.equal(ether('0'));
+  });
+
+  it('should be able to add liquidity optimally with less ETH than required', async () => {
+    const aliceTokenBalanceBefore = await token.balanceOf(alice);
+    const aliceETHBalanceBefore = new BN(await web3.eth.getBalance(alice));
+    await token.approve(ibETHRouter.address, ether('50'), { from: alice });
+    // Depositing 0.1 ETH yield 0.095652174 ibETH
+    // Add 0.095652174 ibETH requires adding 9.5652174 MOCK
+    // Sending 50 MOCK, (50-9.5652174)*0.5 = 20.2173913 MOCK should be used to swap optimally for ibETH
+    // Should get slightly less than 0.202 ibETH from swap.
+    // So should add liquidity total of ~29.7826087 MOCK and ~0.297 ibETH and get ~2.97 lpToken
+    await ibETHRouter.addLiquidityTwoSidesOptimalETH(ether('50'), 0, alice, FOREVER, {
+      from: alice,
+      value: ether('0.1'),
+    });
+    expect(await lp.balanceOf(alice)).to.be.bignumber.equal(ether('2.973189122784300740'));
+    expect(await token.balanceOf(alice)).to.be.bignumber.closeTo(aliceTokenBalanceBefore.sub(ether('50')), new BN('1'));
+    expect(new BN(await web3.eth.getBalance(alice))).to.be.bignumber.closeTo(
+      aliceETHBalanceBefore.sub(ether('0.1')),
+      ether('0.01')
+    );
+    expect(await token.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
+    expect(await bank.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
+    expect(new BN(await web3.eth.getBalance(ibETHRouter.address))).to.be.bignumber.equal(ether('0'));
+  });
+
+  it('should revert when add liquidity optimally ETH with less lpToken than minumum specified', async () => {
+    const aliceTokenBalanceBefore = await token.balanceOf(alice);
+    const aliceETHBalanceBefore = new BN(await web3.eth.getBalance(alice));
+    await token.approve(ibETHRouter.address, ether('50'), { from: alice });
+    // Add 50 MOCK requires adding 0.5 ibETH
+    // Depositing 5 ETH yield 4.7826087 ibETH
+    // Sending 4.7826087 ibETH, (4.7826087-0.5)*0.5 = 2.14130435 ibETH should be used to swap optimally for MOCK
+    // Should get slightly less than 214.130435 MOCK from swap.
+    // So should add liquidity total of ~264 MOCK and ~2.64 ibETH and get ~26.4 lpToken
+    expectRevert(
+      ibETHRouter.addLiquidityTwoSidesOptimalETH(ether('50'), ether('100'), alice, FOREVER, {
+        from: alice,
+        value: ether('5'),
+      }),
+      'IbETHRouter: receive less lpToken than amountLPMin'
+    );
+    expect(await lp.balanceOf(alice)).to.be.bignumber.equal(ether('0'));
+    expect(await token.balanceOf(alice)).to.be.bignumber.equal(aliceTokenBalanceBefore);
+    expect(new BN(await web3.eth.getBalance(alice))).to.be.bignumber.closeTo(aliceETHBalanceBefore, ether('0.01'));
     expect(await token.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
     expect(await bank.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
     expect(new BN(await web3.eth.getBalance(ibETHRouter.address))).to.be.bignumber.equal(ether('0'));
@@ -174,14 +370,16 @@ contract('IbETHRouter', ([deployer, alice]) => {
     const aliceETHBalanceBefore = new BN(await web3.eth.getBalance(alice));
     expect(aliceLPBalanceBefore).to.be.bignumber.above(ether('0'));
     // Deposit 1 ETH, yield 0.95652173913043478 ibETH
-    // Add liquidity with 0.95652173913043478 ibETH and 95.65217391304347800 MOCK
-    // So, removeLiquidity should get 1 ETH and 95.65217391304347800 MOCK back
+    // Add liquidity with 0.95652173913043478 ibETH and 95.652173913043478 MOCK
+    // So, removeLiquidity should get 1 ETH and 95.652173913043478 MOCK back
     await lp.approve(ibETHRouter.address, aliceLPBalanceBefore, { from: alice });
     await ibETHRouter.removeLiquidityETH(aliceLPBalanceBefore, 0, 0, alice, FOREVER, {
       from: alice,
     });
     expect(await lp.balanceOf(alice)).to.be.bignumber.equal(ether('0'));
-    assertAlmostEqual(await token.balanceOf(alice), aliceTokenBalanceBefore.add(ether('95.65217391304347800')));
+    expect(await token.balanceOf(alice)).to.be.bignumber.equal(
+      aliceTokenBalanceBefore.add(ether('95.652173913043478200'))
+    );
     assertAlmostEqual(new BN(await web3.eth.getBalance(alice)), aliceETHBalanceBefore.add(ether('1')));
     expect(await token.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
     expect(await bank.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
@@ -246,13 +444,15 @@ contract('IbETHRouter', ([deployer, alice]) => {
     expect(aliceLPBalanceBefore).to.be.bignumber.above(ether('0'));
     // Deposit 1 ETH, yield 0.95652173913043478 ibETH
     // Add liquidity with 0.95652173913043478 ibETH and 95.65217391304347800 MOCK
-    // So, removeLiquidityAllAlpha should get slightly less than 2*95.65217391304347800 = 191.304348 MOCK (190.116529919717225111)back
+    // So, removeLiquidityAllAlpha should get slightly less than 2*95.65217391304347800 = 191.304348 MOCK (190.116529919717225111)
     await lp.approve(ibETHRouter.address, aliceLPBalanceBefore, { from: alice });
     await ibETHRouter.removeLiquidityAllAlpha(aliceLPBalanceBefore, 0, alice, FOREVER, {
       from: alice,
     });
     expect(await lp.balanceOf(alice)).to.be.bignumber.equal(ether('0'));
-    assertAlmostEqual(await token.balanceOf(alice), aliceTokenBalanceBefore.add(ether('190.116529919717225111')));
+    expect(await token.balanceOf(alice)).to.be.bignumber.equal(
+      aliceTokenBalanceBefore.add(ether('190.116529919717225111'))
+    );
     assertAlmostEqual(new BN(await web3.eth.getBalance(alice)), aliceETHBalanceBefore);
     expect(await token.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
     expect(await bank.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
@@ -380,12 +580,12 @@ contract('IbETHRouter', ([deployer, alice]) => {
     const aliceTokenBalanceBefore = await token.balanceOf(alice);
     // 100 MOCK need ~1 ibETH
     // Deposit 1.045454545454545454 ETH, yield 1 ibETH
-    // so should get add slightly more than 1.045 ETH (1.061262461185886404 ETH)
+    // so should get add slightly more than 1.045 ETH (1.059192269185886404 ETH)
     await ibETHRouter.swapETHForExactAlpha(ether('100'), alice, FOREVER, {
       from: alice,
       value: ether('1.1'),
     });
-    assertAlmostEqual(await web3.eth.getBalance(alice), aliceETHBalanceBefore.sub(ether('1.061262461185886404')));
+    assertAlmostEqual(await web3.eth.getBalance(alice), aliceETHBalanceBefore.sub(ether('1.059192269185886404')));
     expect(await token.balanceOf(alice)).to.be.bignumber.equal(aliceTokenBalanceBefore.add(ether('100')));
     expect(await token.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
     expect(await bank.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
@@ -397,12 +597,12 @@ contract('IbETHRouter', ([deployer, alice]) => {
     const aliceTokenBalanceBefore = await token.balanceOf(alice);
     // 100 MOCK need ~1 ibETH
     // Deposit 1.045454545454545454 ETH, yield 1 ibETH
-    // so should get add slightly more than 1.045 ETH (1.061262461185886404 ETH)
+    // so should get add slightly more than 1.045 ETH (1.059192269185886404 ETH)
     await ibETHRouter.swapETHForExactAlpha(ether('100'), alice, FOREVER, {
       from: alice,
       value: ether('1.059192269185886403'),
     });
-    assertAlmostEqual(await web3.eth.getBalance(alice), aliceETHBalanceBefore.sub(ether('1.061262461185886404')));
+    assertAlmostEqual(await web3.eth.getBalance(alice), aliceETHBalanceBefore.sub(ether('1.059192269185886404')));
     expect(await token.balanceOf(alice)).to.be.bignumber.equal(aliceTokenBalanceBefore.add(ether('100')));
     expect(await token.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));
     expect(await bank.balanceOf(ibETHRouter.address)).to.be.bignumber.equal(ether('0'));


### PR DESCRIPTION
Added
1. `addLiquidityTwoSidesOptimal`
for adding liquidity to ALPHA-ibETH Uniswap pool with either ALPHA or ibETH
2. `addLiquidityTwoSidesOptimalETH`
for adding liquidity to ALPHA-ibETH Uniswap pool with either ALPHA or ETH